### PR TITLE
skip status request errors for correct polling

### DIFF
--- a/src/helpers/walletops.tsx
+++ b/src/helpers/walletops.tsx
@@ -255,7 +255,7 @@ async function pollStatus(txLinker, maxAttempts = 200, delay = 5, setCclMessage,
       setCclMessage("Waiting for TAC OperationId");
     } else {
       updateStage(30);
-      const status = await tracker.getStatusTransaction(operationId);
+      const status = await tracker.getStatusTransaction(operationId).catch(() => '');
       switch (status) {
         case "EVMMerkleMessageCollected":
           //All events collected for sharded message


### PR DESCRIPTION
Sometimes request inside tracker.getStatusTransaction can return 404 and it throws an error, catching promise allow polling to continue